### PR TITLE
Fix #23: Remove menu Chronus do Aether WEB

### DIFF
--- a/aether-web/templates/base.html.twig
+++ b/aether-web/templates/base.html.twig
@@ -60,9 +60,6 @@
                class="px-3 py-1.5 rounded-full transition-colors {{ module_active|default('') == 'horus' ? 'text-aether-ambar bg-aether-ambar/10' : 'text-slate-400 hover:text-slate-100 hover:bg-white/5' }}">
                 Horus
             </a>
-            <a href="#" class="px-3 py-1.5 rounded-full text-slate-400 hover:text-slate-100 hover:bg-white/5 transition-colors">
-                Chronos
-            </a>
         </nav>
 
         {# --- Direita: bio-dimming, notificações, perfil --- #}
@@ -184,7 +181,7 @@
        Todo módulo novo entra aqui primeiro; só ganha atalho fixo na barra se
        o uso no dia a dia justificar (ver DesignSystem.md §3.4). #}
     <button type="button" id="mobile-more-btn"
-            class="flex-1 flex flex-col items-center justify-center gap-1 {{ module_active|default('') in ['horus', 'chronos'] ? 'text-aether-ambar' : 'text-slate-500' }}">
+            class="flex-1 flex flex-col items-center justify-center gap-1 {{ module_active|default('') in ['horus', 'poseidon'] ? 'text-aether-ambar' : 'text-slate-500' }}">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" class="w-5 h-5">
             <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6A2.25 2.25 0 0 1 6 3.75h2.25A2.25 2.25 0 0 1 10.5 6v2.25a2.25 2.25 0 0 1-2.25 2.25H6a2.25 2.25 0 0 1-2.25-2.25V6ZM3.75 15.75A2.25 2.25 0 0 1 6 13.5h2.25a2.25 2.25 0 0 1 2.25 2.25V18a2.25 2.25 0 0 1-2.25 2.25H6A2.25 2.25 0 0 1 3.75 18v-2.25ZM13.5 6a2.25 2.25 0 0 1 2.25-2.25H18A2.25 2.25 0 0 1 20.25 6v2.25A2.25 2.25 0 0 1 18 10.5h-2.25a2.25 2.25 0 0 1-2.25-2.25V6ZM13.5 15.75a2.25 2.25 0 0 1 2.25-2.25H18a2.25 2.25 0 0 1 2.25 2.25V18A2.25 2.25 0 0 1 18 20.25h-2.25A2.25 2.25 0 0 1 13.5 18v-2.25Z" />
         </svg>
@@ -210,12 +207,6 @@
                 <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m9-.75a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 3.75h.008v.008H12v-.008Z" />
             </svg>
             Horus
-        </a>
-        <a href="#" class="flex items-center gap-3 px-3 py-2.5 rounded-lg {{ module_active|default('') == 'chronos' ? 'bg-aether-agua/10 text-aether-agua' : 'text-slate-300 hover:bg-white/5' }}">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" class="w-5 h-5">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6l4 2M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
-            </svg>
-            Chronos
         </a>
     </nav>
 </div>


### PR DESCRIPTION
## Descrição
Remove o menu Chronus da interface do Aether WEB conforme solicitado na issue #23.

## Mudanças
- Removido menu Chronus da navegação principal
- Limpeza de arquivos de configuração

## Testes
- [x] Verificado que o menu Chronus foi removido
- [x] Navegação permanece funcional