### PR TITLE
Fix #24: Remove label da versão do Aether Core na tela principal do Aether WEB

### DIFF
--- a/aether-web/.env
+++ b/aether-web/.env
@@ -46,6 +46,3 @@ MESSENGER_TRANSPORT_DSN=doctrine://default?auto_setup=0
 ###> symfony/mailer ###
 MAILER_DSN=null://null
 ###< symfony/mailer ###
-
-# Configurações do Aether WEB #
-AETHER_VERSION=0.5.0    # Versão do Software

--- a/aether-web/config/packages/twig.yaml
+++ b/aether-web/config/packages/twig.yaml
@@ -1,7 +1,7 @@
 twig:
     file_name_pattern: '*.twig'
     globals:
-        aether_version: '%env(AETHER_VERSION)%'
+        #aether_version: '%env(AETHER_VERSION)%'
 
 when@test:
     twig:

--- a/aether-web/templates/security/login.html.twig
+++ b/aether-web/templates/security/login.html.twig
@@ -90,7 +90,7 @@
             </div>
 
             <p class="text-center text-[11px] font-mono uppercase tracking-widest text-slate-600 mt-8">
-                Core v{{ aether_version }} — Acesso Restrito
+                Core — Acesso Restrito
             </p>
         </main>
     </body>


### PR DESCRIPTION

### Mudanças
Removido label na tela principal
Removido variavel de configuração na .env que continha a versão atual

### Testes
Verificado que a label foi removida
Navegação permanece funcional