### PR TITLE
Improv #35 - Remove o botão debug atuar do Horus Gate

### DIFF
--- a/aether-web/public/build/app.css
+++ b/aether-web/public/build/app.css
@@ -813,9 +813,6 @@
     }
     --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
   }
-  .object-cover {
-    object-fit: cover;
-  }
   .object-fill {
     object-fit: fill;
   }
@@ -1125,14 +1122,6 @@
     @supports (color: color-mix(in lab, red, red)) {
       .hover\:border-aether-broto\/30:hover {
         border-color: color-mix(in oklab, var(--color-aether-broto) 30%, transparent);
-      }
-    }
-    .hover\:bg-aether-ambar\/10:hover {
-      background-color: color-mix(in srgb, #FFB900 10%, transparent);
-    }
-    @supports (color: color-mix(in lab, red, red)) {
-      .hover\:bg-aether-ambar\/10:hover {
-        background-color: color-mix(in oklab, var(--color-aether-ambar) 10%, transparent);
       }
     }
     .hover\:bg-aether-broto\/20:hover {

--- a/aether-web/public/js/services/horus_gate_control.js
+++ b/aether-web/public/js/services/horus_gate_control.js
@@ -1,0 +1,39 @@
+/* public/js/services/horus_gate_control.js
+
+   Aciona o portão do Horus via um endpoint do próprio Symfony (mesma
+   origem)
+
+   Contrato de atributos esperado no botão:
+     - data-url          : rota Symfony que recebe o POST (renderizada
+                            via path() no Twig, nunca hardcoded aqui —
+                            este arquivo é servido estático e não passa
+                            pelo parser do Twig).
+     - data-cooldown-ms   : opcional, tempo em ms que o botão fica
+                            desabilitado após o clique (padrão 4000).
+                            Evita reacionar enquanto o portão físico
+                            ainda está em movimento.
+*/
+(function () {
+    const botao = document.getElementById('btn-portao-atuador');
+    if (!botao) return;
+
+    botao.addEventListener('click', async () => {
+        const textoOriginal = botao.textContent;
+        botao.disabled = true;
+        botao.textContent = 'Enviando...';
+
+        try {
+            const resp = await fetch(botao.dataset.url, { method: 'POST' });
+            if (!resp.ok) throw new Error(`Symfony respondeu ${resp.status}`);
+        } catch (erro) {
+            console.error('Erro ao enviar comando de debug ao portao:', erro);
+            botao.classList.add('atuador-erro');
+            setTimeout(() => botao.classList.remove('atuador-erro'), 1300);
+        } finally {
+            setTimeout(() => {
+                botao.disabled = false;
+                botao.textContent = textoOriginal;
+            }, Number(botao.dataset.cooldownMs) || 4000);
+        }
+    });
+})();

--- a/aether-web/templates/modulos/horus.html.twig
+++ b/aether-web/templates/modulos/horus.html.twig
@@ -110,17 +110,10 @@
                        sem estado (o portão não sabe se vai abrir ou fechar, depende
                        de onde ele parou fisicamente). Não usa role="switch"/aria-checked
                        porque não há "ligado/desligado" pra representar. #}
-                    <button type="button" data-modulo="horus" data-acao="portao_atuar" data-cooldown-ms="4000"
+                    <button type="button" id="btn-portao-atuador" data-cooldown-ms="4000"
+                            data-url="{{ path('app_horus_portao_debug_abrir') }}"
                             class="px-3 py-2 rounded-lg text-xs font-medium text-slate-300 border border-aether-border hover:bg-white/5 transition-colors whitespace-nowrap disabled:opacity-50 disabled:cursor-wait">
                         Atuar
-                    </button>
-
-                    {# TEMPORÁRIO: botão de debug, envia direto pro servidor de
-                       debug do ESP32 via Symfony (ver GateDebugController).
-                       Remover quando o fluxo oficial acima estiver funcional. #}
-                    <button type="button" id="btn-debug-portao" data-cooldown-ms="4000"
-                            class="px-3 py-2 rounded-lg text-xs font-medium text-aether-ambar border border-aether-ambar/40 hover:bg-aether-ambar/10 transition-colors whitespace-nowrap disabled:opacity-50 disabled:cursor-wait">
-                        Debug: Abrir
                     </button>
                 </div>
             </div>
@@ -208,32 +201,5 @@
 
 {% block javascripts %}
     <script src="{{ asset('js/services/camera_snapshot.js') }}"></script>
-
-    {# TEMPORÁRIO: ver botão #btn-debug-portao acima. #}
-    <script>
-        (function () {
-            const botao = document.getElementById('btn-debug-portao');
-            if (!botao) return;
-
-            botao.addEventListener('click', async () => {
-                const textoOriginal = botao.textContent;
-                botao.disabled = true;
-                botao.textContent = 'Enviando...';
-
-                try {
-                    const resp = await fetch('{{ path('app_horus_portao_debug_abrir') }}', { method: 'POST' });
-                    if (!resp.ok) throw new Error(`Symfony respondeu ${resp.status}`);
-                } catch (erro) {
-                    console.error('Erro ao enviar comando de debug ao portao:', erro);
-                    botao.classList.add('atuador-erro');
-                    setTimeout(() => botao.classList.remove('atuador-erro'), 1300);
-                } finally {
-                    setTimeout(() => {
-                        botao.disabled = false;
-                        botao.textContent = textoOriginal;
-                    }, Number(botao.dataset.cooldownMs) || 4000);
-                }
-            });
-        })();
-    </script>
+    <script src="{{ asset('js/services/horus_gate_control.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
Remove o botão de debug e unifica a função no botão original chamado "Atuar". A função por tras ainda faz o mesmo processo que deve ser refatorado no futuro.